### PR TITLE
Fix ResourceQuota pod count type to string

### DIFF
--- a/charts/gatekeeper/templates/gatekeeper-critical-pods-resourcequota.yaml
+++ b/charts/gatekeeper/templates/gatekeeper-critical-pods-resourcequota.yaml
@@ -12,7 +12,7 @@ metadata:
   namespace: '{{ .Release.Namespace }}'
 spec:
   hard:
-    pods: {{ .Values.podCountLimit }}
+    pods: '{{ .Values.podCountLimit }}'
   scopeSelector:
     matchExpressions:
     - operator: In


### PR DESCRIPTION
 .spec.hard.pods: expected string. This causes kubeval and google config sync to fail static checking before applying:
```
failed to apply ResourceQuota, gatekeeper-system/gatekeeper-critical-pods: failed to create typed patch object: .spec.hard.pods: expected string, got &value.valueUnstructured{Value:100}
```

See: https://kubernetes.io/docs/concepts/policy/resource-quotas/